### PR TITLE
O2533 wave 2

### DIFF
--- a/om_account_budget/models/account_budget.py
+++ b/om_account_budget/models/account_budget.py
@@ -103,6 +103,7 @@ class CrossoveredBudgetLines(models.Model):
         help="Amount really earned/spent.")
     practical_amount = fields.Monetary(string='Practical Amount',
                                        help="Amount really earned/spent.")
+    difference_amount = fields.Monetary(string='Difference', )
     company_id = fields.Many2one(related='crossovered_budget_id.company_id', comodel_name='res.company',
         string='Company', store=True, readonly=True)
     crossovered_budget_state = fields.Selection(related='crossovered_budget_id.state', string='Budget State', store=True, readonly=True)
@@ -175,6 +176,7 @@ class CrossoveredBudgetLines(models.Model):
             practical_amount = self.env.cr.fetchone()[0] or 0.0
             line.write({
                 'practical_amount': practical_amount,
+                'difference_amount': line.planned_amount - practical_amount,
             })
             line.computed_practical_amount = practical_amount
 

--- a/om_account_budget/views/account_analytic_account_views.xml
+++ b/om_account_budget/views/account_analytic_account_views.xml
@@ -22,7 +22,14 @@
                                            invisible="1"/>
                                     <field name="practical_amount"
                                            sum="Practical Amount"
+                                           readonly="1"
+                                           force_save="1"
                                            widget="monetary"/>
+                                    <field name="difference_amount"
+                                           readonly="1"
+                                           force_save="1"
+                                           widget="monetary"
+                                           sum="Total Difference"/>
                                 </tree>
                                 <form string="Budget Items">
                                     <field name="crossovered_budget_id"/>

--- a/om_account_budget/views/account_budget_views.xml
+++ b/om_account_budget/views/account_budget_views.xml
@@ -113,7 +113,10 @@
                                            invisible="1"/>
                                     <field name="practical_amount" readonly="1"
                                            force_save="1"
-                                           sum="Practical Amount"/>
+                                           sum="Total Practical Amount"/>
+                                    <field name="difference_amount" readonly="1"
+                                           force_save="1"
+                                           sum="Total Difference"/>
                                     <button type="object" name="action_open_budget_entries" string="Entries..."
                                             icon="fa-arrow-circle-o-right"/>
                                 </tree>
@@ -280,7 +283,14 @@
                 <field name="paid_date" groups="base.group_no_one"  />
                 <field name="planned_amount"/>
                 <field name="computed_practical_amount" invisible="1"/>
-                <field name="practical_amount" readonly="1" force_save="1"/>
+                <field name="practical_amount" readonly="1"
+                       force_save="1"
+                       sum="Total Practical Amount"
+                />
+                <field name="difference_amount"
+                       readonly="1"
+                       force_save="1"
+                       sum="Total Difference"/>
             </tree>
         </field>
     </record>
@@ -302,6 +312,8 @@
                         <field name="planned_amount" attrs="{'readonly':[('crossovered_budget_state','!=','draft')]}"/>
                         <field name="computed_practical_amount" invisible="1"/>
                         <field name="practical_amount" readonly="1" force_save="1"/>
+                        <field name="difference_amount"
+                               readonly="1" force_save="1"/>
                         <field name="company_id" options="{'no_create': True}" groups="base.group_multi_company"  attrs="{'readonly':[('crossovered_budget_state','!=','draft')]}"/>
                     </group>
                 </sheet>
@@ -317,6 +329,7 @@
                 <field name="crossovered_budget_id" type="row"/>
                 <field name="planned_amount"  type="measure" string="Planned amount"/>
                 <field name="practical_amount" type="measure" string="Practical amount"/>
+                <field name="difference_amount" type="measure" string="Difference"/>
             </pivot>
         </field>
     </record>
@@ -329,6 +342,7 @@
                 <field name="crossovered_budget_id" type="row"/>
                 <field name="planned_amount"  type="measure" string="Planned amount"/>
                 <field name="practical_amount" type="measure" string="Practical amount"/>
+                <field name="difference_amount" type="measure" string="Difference"/>
             </graph>
         </field>
     </record>


### PR DESCRIPTION
 Invoicing >> Account >> Budgets >> In the form view >> "Budget Lines" tab >> List view >>
-> Remove "Theoretical Amount" and "Achievement"
-> Add a new column "Difference" which shows the value of "Planned Amount" - "Practical Amount". Similar to  "Planned Amount" & "Practical Amount" show the totals for "Difference" too.
In Invoicing >> Reporting >> Management >> Budget Analysis >> Click on the pivot table and it throws the following error: Cannot aggregate field 'theoritical_amount'. As part of the above changes, we no longer theoretical amount.