### PR TITLE
O2534 wave 1

### DIFF
--- a/uk_accounting/__manifest__.py
+++ b/uk_accounting/__manifest__.py
@@ -51,5 +51,6 @@
         'data/account_chart_template_data.xml',
         'data/ir_sequence_data.xml',
         'views/account_account_view.xml',
+        'views/account_move_view.xml',
     ],
 }

--- a/uk_accounting/views/account_account_view.xml
+++ b/uk_accounting/views/account_account_view.xml
@@ -40,9 +40,5 @@
           <field name="context">{'show_parent_account':True}</field>
       </record>
 
-      <record model="ir.ui.menu" id="account.menu_action_account_moves_all">
-          <field name="groups_id" eval="[(6,0,[ref('base.group_no_one'),ref('account.group_account_user')])]"/>
-      </record>
-
   </data>
 </odoo>

--- a/uk_accounting/views/account_move_view.xml
+++ b/uk_accounting/views/account_move_view.xml
@@ -1,0 +1,20 @@
+<odoo>
+  <data>
+
+      <record model="ir.ui.menu" id="account.menu_action_account_moves_all">
+          <field name="groups_id" eval="[(6,0,[ref('base.group_no_one'),ref('account.group_account_user')])]"/>
+      </record>
+
+      <record id="view_move_form_uk_inherit" model="ir.ui.view">
+          <field name="name">account.move.uk.inherit</field>
+          <field name="model">account.move</field>
+          <field name="inherit_id" ref="account.view_move_form"/>
+          <field name="arch" type="xml">
+              <xpath expr="//notebook/page[@id='aml_tab']/field[@name='line_ids']/tree/field[@name='analytic_account_id']" position="attributes">
+                  <attribute name="optional">show</attribute>
+              </xpath>
+          </field>
+      </record>
+
+  </data>
+</odoo>


### PR DESCRIPTION
1)
In Invoicing >> Accounting >> Journal items >> 
-- This menu is currently visible only if the developer mode is activated.  , should be visible for account user without developer mode

2
 In Invoicing >> Accounting >> Journal Entries >> "Journal Items" tab >> Tree view >> To the right of "Account", show "Analytic Account" if   In Invoicing >> Configuration >> Settings >> "Analytic Accounting" is enabled.

I added default to be optional=show like it is on invoice lines, to be consistent