### PR TITLE
[O2541] Change om_account_budget field strings

### DIFF
--- a/om_account_budget/models/account_budget.py
+++ b/om_account_budget/models/account_budget.py
@@ -95,15 +95,15 @@ class CrossoveredBudgetLines(models.Model):
     paid_date = fields.Date('Paid Date')
     currency_id = fields.Many2one('res.currency', related='company_id.currency_id', readonly=True)
     planned_amount = fields.Monetary(
-        'Planned Amount', required=True,
+        'Budget', required=True,
         help="Amount you plan to earn/spend. Record a positive amount if it is a revenue and a negative amount if it is a cost.")
     computed_practical_amount = fields.Monetary(
         compute='_compute_practical_amount',
         string='Computed Practical Amount',
         help="Amount really earned/spent.")
-    practical_amount = fields.Monetary(string='Practical Amount',
+    practical_amount = fields.Monetary(string='Actual',
                                        help="Amount really earned/spent.")
-    difference_amount = fields.Monetary(string='Difference', )
+    difference_amount = fields.Monetary(string='Variance', )
     company_id = fields.Many2one(related='crossovered_budget_id.company_id', comodel_name='res.company',
         string='Company', store=True, readonly=True)
     crossovered_budget_state = fields.Selection(related='crossovered_budget_id.state', string='Budget State', store=True, readonly=True)

--- a/om_account_budget/views/account_analytic_account_views.xml
+++ b/om_account_budget/views/account_analytic_account_views.xml
@@ -21,7 +21,7 @@
                                     <field name="computed_practical_amount"
                                            invisible="1"/>
                                     <field name="practical_amount"
-                                           sum="Practical Amount"
+                                           sum="Actual"
                                            readonly="1"
                                            force_save="1"
                                            widget="monetary"/>

--- a/om_account_budget/views/account_budget_views.xml
+++ b/om_account_budget/views/account_budget_views.xml
@@ -108,7 +108,7 @@
                                     <field name="date_to"/>
                                     <field name="paid_date" groups="base.group_no_one"/>
                                     <field name="currency_id" invisible="1"/>
-                                    <field name="planned_amount" sum="Planned Amount"/>
+                                    <field name="planned_amount" sum="Total Budget"/>
                                     <field name="computed_practical_amount"
                                            invisible="1"/>
                                     <field name="practical_amount" readonly="1"
@@ -327,9 +327,9 @@
         <field name="arch" type="xml">
             <pivot string="Budget Lines">
                 <field name="crossovered_budget_id" type="row"/>
-                <field name="planned_amount"  type="measure" string="Planned amount"/>
-                <field name="practical_amount" type="measure" string="Practical amount"/>
-                <field name="difference_amount" type="measure" string="Difference"/>
+                <field name="planned_amount"  type="measure" string="Budget"/>
+                <field name="practical_amount" type="measure" string="Actual"/>
+                <field name="difference_amount" type="measure" string="Variance"/>
             </pivot>
         </field>
     </record>
@@ -341,8 +341,8 @@
             <graph string="Budget Lines">
                 <field name="crossovered_budget_id" type="row"/>
                 <field name="planned_amount"  type="measure" string="Planned amount"/>
-                <field name="practical_amount" type="measure" string="Practical amount"/>
-                <field name="difference_amount" type="measure" string="Difference"/>
+                <field name="practical_amount" type="measure" string="Actual"/>
+                <field name="difference_amount" type="measure" string="Variance"/>
             </graph>
         </field>
     </record>


### PR DESCRIPTION
From task:

The following changes are required on the accounting package:

First, enable developer mode, and tick 'Show Full Accounting Features' on the user you are logged in as.
In Invoicing >> Accounting >> Budgets >> In Budget Lines >> Rename the field names of the columns:
-- "Planned Amount" to "Budget"
-- "Practical Amount" to "Actual"
-- "Difference" to "Variance"


The changes should also be reflected in 
In Invoicing >>  Reporting >>  Management >> Budget Analysis >> in the list view, pivot table and its measures