### PR TITLE
[O2552] Handle no tax present in compute_all override

### DIFF
--- a/uk_accounting/models/account_tax.py
+++ b/uk_accounting/models/account_tax.py
@@ -75,6 +75,11 @@ class AccountTaxMargin(models.Model):
             total_res['taxes'].append(lst_taxes)
             total_base += lst_taxes['base']
             total_tax += lst_taxes['amount']
+        # If no taxes are present, we should fallback to res values
+        # rather than arbitrarily leaving total_base and total_tax at 0
+        if not res['taxes']:
+            total_base = res.get('total_excluded', 0.00)
+            total_tax = 0
         total_res['total_included'] = total_base + total_tax
         total_res['total_excluded'] = total_base
         total_res['total_void'] = total_base + total_tax


### PR DESCRIPTION
We (fortunately) only picked up on this due to a RM test checking purchase apporval.

RM tests all passed until `uk_accounting` module was installed.

The test case sets _no_ tax ids on a purchase line (500 units at 500 price unit) and then checks that the purchase amount is greater than the default minimum purchase approval amount (5,000). The test case failed. After digging it appeared that the `compute_all` override contained a bug that if no tax was present, total_included, excluded, and void were all overwritten with `0`