### PR TITLE
Fixes unable to reconcile bank statement line

### DIFF
--- a/uk_accounting/models/account_payment.py
+++ b/uk_accounting/models/account_payment.py
@@ -142,7 +142,7 @@ class AccountPaymentRegister(models.TransientModel):
                 defaults['payment_method_id'] = self.env[
                     'account.payment.method'].search(domain, limit=1).id
         return defaults
-    
+
     def check_combined_configuration(self):
         return self.env.user.company_id.combined_payment
 


### PR DESCRIPTION
The RM project currently points to UK Accounting commit 149eed0. I have created another branch called 'royal-marsden' which is based on this commit.

The uk_accounting module has since been refactored and anything after the commit referenced above will not work with RM (this is because of a fundamental design flaw when the original uk_accounting module was created). The new branch 'royal-marsden' should be considered as the '13.0' branch for RM. Therefore this PR will be to merge the code change into the 'royal-marsden' branch.

The RM docker image for staging will be built using the latest commit in this PR and deployed to staging for testing. Once approved the PR will be merged and the RM project will then be updated to point to the latest commit on the 'royal-marsden' branch.


- [FIX] Unable to reconcile bank statement line
  The uk_accounting module uses a copy/paste of a base method with a couple of changes. The parts that are unchanged do not occur in the same order as they did in the base file

  Fixes #17280

- [REF] Incorrect indentation method