### PR TITLE
Remaining value incorrect in depreciation

### DIFF
--- a/uk_account_asset/models/account_asset.py
+++ b/uk_account_asset/models/account_asset.py
@@ -760,7 +760,7 @@ class AccountAssetAsset(models.Model):
             self.mapped('depreciation_line_ids').unlink()
         self.write({'state': 'draft', 'value_alr_accumulated': 0,
                     'date_value_alr_acc': False})
-        
+
     def get_asset_code(self):
         active_asset_ids = self.search([
             ('code', '!=', False),


### PR DESCRIPTION
- [FIX] Unused imports
- [FIX] Remaining value incorrect in depreciation
  When an asset depreciates the first month after the depreciation starts should be starting value - one months value (was previously just starting value)
- [META] Unnecessary spaces on blank line